### PR TITLE
#9 / スケジュールクリック時のイベント発火を修正

### DIFF
--- a/app/javascript/components/CalendarComponent.vue
+++ b/app/javascript/components/CalendarComponent.vue
@@ -37,6 +37,7 @@
           :value="today"
           :events="events"
           color="primary"
+          @click:event="clickEvent"
           @click:date="showDay"
           @click:day="createEvent"
       ></v-calendar>
@@ -86,6 +87,16 @@
         console.log("calendarcompoennt.xue");
         this.events.push(params);
         console.log(`保存しました。${params}`)
+      },
+       // event → day の順番で呼ばれる。
+      clickEvent( {nativeEvent,event} ){
+        console.log("clickEvetn");
+        console.log(event);
+        console.log(event.name)
+        
+        //次にcreateEventが走ってしまうのを防御する
+        nativeEvent.stopPropagation();
+        
       }
     }
   }


### PR DESCRIPTION
スケジールクリック時に
スケジュール新規登録のTimePickerが出現されるのを
されないようイベント変更
[![Image from Gyazo](https://i.gyazo.com/af1ebbc2be2639a55ec17b682acf0b16.gif)](https://gyazo.com/af1ebbc2be2639a55ec17b682acf0b16)